### PR TITLE
pagina plan de ventas y modal del reporte con embebido

### DIFF
--- a/logistica-ccp/__tests__/sales.test.tsx
+++ b/logistica-ccp/__tests__/sales.test.tsx
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import Sales from '@/app/[locale]/sales/page'
+import fetchMock from 'jest-fetch-mock'
+import userEvent from '@testing-library/user-event'
+// import * as microserviceStock from '@/app/[locale]/stock/adapters/microserviceStock'
+
+describe('Vista de creación de planes de ventas', () => {
+
+    it('Validar renderizado de la vista', () => {
+        render(<Sales />)
+        const heading = screen.getByRole('heading', { level: 1 })
+        expect(heading).toBeInTheDocument()
+    })
+
+    it('Renderizar tabla principal', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 1, estado: 'Activo', fecha_inicio: '2024-03-24', fecha_fin: '2024-03-31', meta_ventas: 1000000, productos: 10 }]));
+        render(<Sales />)
+        await waitFor(() => {
+            const table = screen.getByRole('grid')
+            expect(table).toBeInTheDocument()
+        })        
+    })
+
+    it('Renderizado de botones', () => {
+        render(<Sales />)
+        const addButton = screen.getAllByRole('button')
+        expect(addButton).toHaveLength(3)
+    })
+})

--- a/logistica-ccp/locales/en.json
+++ b/logistica-ccp/locales/en.json
@@ -9,7 +9,8 @@
         "option_2": "Products",
         "option_3": "Stock",
         "option_4": "Sellers",
-        "option_5": "Orders"
+        "option_5": "Orders",
+        "option_6": "Sales Planning"
     },
     "ConfigMenu": {
         "title": "Configuration",
@@ -105,6 +106,27 @@
         "table_col_6": "Latitude",
         "table_col_7": "Longitude",
         "table_col_8": "Delivery Route",
+        "route_modal_title": "Delivery Route",
+        "route_modal_order": "Order: ",
+        "route_modal_customer": "Customer: ",
+        "route_modal_address": "Address: ",
+        "route_modal_table_col_1": "SKU",
+        "route_modal_table_col_2": "Warehouse",
+        "button_close": "CLOSE"
+    },
+    "Sales": {
+        "title": "Sales Planning",
+        "table_col_1": "ID",
+        "table_col_2": "Status",
+        "table_col_3": "Creation Date",
+        "table_col_4": "End Date",
+        "table_col_5": "Goal",
+        "table_col_6": "Products",
+        "Report": "Report",
+        "modal_title": "Sales Report",
+        "modal_subtitle": "Sales report for the period: ",
+        "modal_button_close": "CLOSE",
+
         "route_modal_title": "Delivery Route",
         "route_modal_order": "Order: ",
         "route_modal_customer": "Customer: ",

--- a/logistica-ccp/locales/es.json
+++ b/logistica-ccp/locales/es.json
@@ -9,7 +9,8 @@
         "option_2": "Productos",
         "option_3": "Inventario",
         "option_4": "Vendedores",
-        "option_5": "Pedidos"
+        "option_5": "Pedidos",
+        "option_6": "Plan de ventas"
     },
     "ConfigMenu": {
         "title": "Opciones",
@@ -112,5 +113,26 @@
         "route_modal_table_col_1": "SKU",
         "route_modal_table_col_2": "Bodega",
         "button_close": "CERRAR"
+    },
+    "Sales": {
+        "title": "Plan de ventas",
+        "table_col_1": "ID",
+        "table_col_2": "Estado",
+        "table_col_3": "Fecha Inicio",
+        "table_col_4": "Fecha Fin",
+        "table_col_5": "Meta",
+        "table_col_6": "Productos",
+        "Report": "Reporte",
+        "modal_title": "Reporte Plan de Ventas",
+        "modal_subtitle": "Reporte de Ventas para el periodo: ",
+        "modal_button_close": "CERRAR",
+
+        "route_modal_title": "Delivery Route",
+        "route_modal_order": "Order: ",
+        "route_modal_customer": "Customer: ",
+        "route_modal_address": "Address: ",
+        "route_modal_table_col_1": "SKU",
+        "route_modal_table_col_2": "Warehouse",
+        "button_close": "CLOSE"
     }
 }

--- a/logistica-ccp/src/app/[locale]/sales/ModalReport.tsx
+++ b/logistica-ccp/src/app/[locale]/sales/ModalReport.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from "react";
+import { SelectChangeEvent } from "@mui/material";
+import { Modal, Box, Select, Typography, TextField, Button, Stack, MenuItem, InputLabel } from "@mui/material"
+import Grid from "@mui/material/Grid2";
+
+import { useTranslations } from "next-intl";
+
+interface ModalProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+export default function ModalReport({ open, onClose }: ModalProps) {
+    const t = useTranslations('Sales')
+
+    return (
+        <Modal 
+            open={open}
+            onClose={onClose}
+            aria-labelledby="modal-formulario-crear-producto"
+            aria-describedby="modal-formulario-crear-producto-descripcion"
+            sx={{
+                "& .MuiBackdrop-root": {
+                    backgroundColor: "RGBA(248, 248, 248, 0.6)",
+                    backdropFilter: "blur(4px)"
+                }
+            }}
+        >
+            <Box sx={{ height: "100%" }}>
+                <Grid container sx={{ height: "100%" }}>
+                    <Grid sx={{ 
+                        backgroundColor: "white", 
+                        borderRadius: "16px",
+                        boxShadow: "3",
+                        direction: "column", 
+                        minHeight: "40rem", 
+                        margin: "auto",
+                        padding: "2rem",
+                        width: "60rem",
+                        }}
+                        title="Formulario Ingresar Producto a Stock"
+                    >
+                        <Typography id="modal-formulario-producto-title"
+                                variant="h6"
+                                title="Form title"
+                                gutterBottom>
+                            {t('modal_title')}
+                        </Typography>
+                        <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden' }}>
+                            <iframe
+                                width="850"
+                                height="600"
+                                src="https://lookerstudio.google.com/embed/reporting/dded8e5f-cdcb-4201-8842-943b616ab40f/page/eEUJF"
+                                // frameborder="0"
+                                style={{ border: 0, display: 'block', margin: '0 auto' }} 
+                                allowFullScreen
+                                sandbox="allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox">
+                            </iframe>
+                        </div>
+                        
+                        <Button onClick={onClose} variant="contained" color="error" sx={{ display: 'block', margin: '1rem auto' }}>
+                            {t('modal_button_close')}
+                        </Button>
+
+                    </Grid>
+                </Grid>
+            </Box>
+        </Modal>
+    )
+}

--- a/logistica-ccp/src/app/[locale]/sales/Sales.module.css
+++ b/logistica-ccp/src/app/[locale]/sales/Sales.module.css
@@ -1,0 +1,10 @@
+.TextField {
+    background-color: #fff;
+    border-radius: 10%;
+    margin: 0;
+    width: 450px;
+}
+
+.TextField.MuiOutlinedInput-notchedOutline {
+    border-radius: 16px;
+}

--- a/logistica-ccp/src/app/[locale]/sales/page.tsx
+++ b/logistica-ccp/src/app/[locale]/sales/page.tsx
@@ -1,0 +1,77 @@
+"use client"
+import React, { useState, useEffect } from "react";
+import styles from "./Sales.module.css"
+import DataTable from "../../../globalComponents/Datatable";
+import PageTitle from "../../../globalComponents/PageTitle";
+import Grid from "@mui/material/Grid2";
+import { ThemeProvider, Box, Stack, Button } from "@mui/material";
+import { GridColDef } from "@mui/x-data-grid";
+import AddIcon from '@mui/icons-material/Add';
+import { useTranslations } from "next-intl";
+import ModalReport from "./ModalReport";
+
+declare module '@mui/material/Button' {
+    interface ButtonPropsColorOverrides {
+        cpp: true;
+        dark: true;
+    }
+}
+
+interface Sales {
+    id: string;
+    estado: string;
+    fecha_inicio: string;
+    fecha_fin: string;
+    meta_ventas: number;
+    productos: number;
+}
+
+
+const Sales: React.FC = () => {
+    const t = useTranslations('Sales')
+
+    const tableSchema: GridColDef[] = [
+        {field: 'ID Plan Ventas', headerName: t('table_col_1'), flex: 1, headerClassName: styles.Header},
+        {field: 'Estado', headerName: t('table_col_2'), flex: 1, headerClassName: styles.Header},
+        {field: 'Fecha Inicio', headerName: t('table_col_3'), flex: 1, headerClassName: styles.Header},
+        {field: 'Fecha Fin', headerName: t('table_col_4'), flex: 1, headerClassName: styles.Header},
+        {field: 'Meta Ventas', headerName: t('table_col_5'), flex: 1, headerClassName: styles.Header},
+        {field: 'Productos', headerName: t('table_col_6'), flex: 1, headerClassName: styles.Header}
+    ]
+
+    const [isOpenReport, setIsOpenReport] = useState(false);
+    const [sales, setSales] = useState<Sales[]>([])
+
+
+    return (
+        <Box>
+            <Grid container>
+                <ModalReport open={isOpenReport} onClose={() => setIsOpenReport(false)} />
+                <Grid sx={{ direction: 'column' }} size="grow">
+                <PageTitle text={t('title')} />
+                    <Grid container size="grow" sx={{ direction: 'row', marginLeft: '6.25rem', height: '40px' }}>
+                        <Grid size="grow" sx={{ marginRight: '6.25rem' }}>
+                            <Stack spacing={2} direction="row" justifyContent={'flex-end'}>
+                                <Button
+                                    onClick={() => setIsOpenReport(true)}
+                                    variant="contained"
+                                    color="cpp"
+                                    startIcon={<AddIcon />}
+                                    data-testid="addStock"
+                                >
+                                    {t('Report')}
+                                </Button>
+                            </Stack>
+                        </Grid>
+                    </Grid>
+                    <Grid size="grow" sx={{ margin: '1.25rem 6.25rem' }}>
+                        <DataTable columns={tableSchema} rows={sales} />
+                    </Grid>
+                </Grid>
+                
+
+            </Grid>
+        </Box>
+    )}
+
+export default Sales;

--- a/logistica-ccp/src/globalComponents/Sidebar.tsx
+++ b/logistica-ccp/src/globalComponents/Sidebar.tsx
@@ -61,6 +61,11 @@ const Sidebar: React.FC = () => {
                     {translations("option_5")}
                   </Link>
                 </li>
+                <li className="mb-3">
+                  <Link href="/sales" className="hover:text-gray-300">
+                    {translations("option_6")}
+                  </Link>
+                </li>
               </ul>
             </nav>
             </Grid>


### PR DESCRIPTION
This pull request introduces a new "Sales Planning" feature, including the implementation of a sales planning page, a modal for sales reports, and updates to localization files for both English and Spanish. It also includes corresponding tests and styling updates.

### Feature Implementation:

* **Sales Planning Page**: Added a new `Sales` page (`logistica-ccp/src/app/[locale]/sales/page.tsx`) with a data table displaying sales plans and a button to open a sales report modal. The page uses translations for dynamic text and integrates with global components like `DataTable` and `PageTitle`. ([logistica-ccp/src/app/[locale]/sales/page.tsxR1-R77](diffhunk://#diff-ebfd5b14b2cc2626af7d6bc2a18ba0ce95d5b0c59f7200adb04a073e865420caR1-R77))
* **Sales Report Modal**: Implemented a modal component (`ModalReport`) for displaying sales reports, with an embedded iframe for report visualization. The modal uses translations for its content. ([logistica-ccp/src/app/[locale]/sales/ModalReport.tsxR1-R70](diffhunk://#diff-8de2db200d39e265030cb79ea2907349452f6737894a34a089d44b83ab4f379aR1-R70))

### Localization Updates:

* **English (`en.json`)**: Added translations for the "Sales Planning" page, including table column headers, modal titles, and button text. [[1]](diffhunk://#diff-9a3481bbf969ff5c6785846d434fa2de19748a762bf6ee87891b3c0435b70498L12-R13) [[2]](diffhunk://#diff-9a3481bbf969ff5c6785846d434fa2de19748a762bf6ee87891b3c0435b70498R109-R129)
* **Spanish (`es.json`)**: Added corresponding translations for the "Plan de ventas" page, ensuring consistency with the English version. [[1]](diffhunk://#diff-80b541fed4a58363736db050b26c8e5157818988552ea8ea08420f25000b19f0L12-R13) [[2]](diffhunk://#diff-80b541fed4a58363736db050b26c8e5157818988552ea8ea08420f25000b19f0R116-R136)

### UI Enhancements:

* **Styling for Sales Page**: Added CSS styles in `Sales.module.css` for consistent UI elements like text fields. ([logistica-ccp/src/app/[locale]/sales/Sales.module.cssR1-R10](diffhunk://#diff-a676e77f2a84d58f895d79e3eb8cad0e89c6e6b8d9895eb59f8b8a59c75c70a0R1-R10))

### Navigation Update:

* **Sidebar Integration**: Updated the global sidebar to include a link to the new "Sales Planning" page.

### Testing:

* **Unit Tests**: Added tests for the `Sales` page to validate rendering of the main view, table, and buttons.