### PR TITLE
Feat/lista planes

### DIFF
--- a/logistica-ccp/__tests__/salesMicroservice.test.tsx
+++ b/logistica-ccp/__tests__/salesMicroservice.test.tsx
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom'
+import * as microserviceSales from '@/app/[locale]/sales/adapters/microserviceSales'
+import fetchMock from 'jest-fetch-mock'
+
+describe('Interacción con microservicio de ventas', () => {
+
+    const salesPlanData = [{
+        id: '1',
+        estado: 'Activo',
+        fecha_inicio: 'Sun, 04 May 2025 15:50:41 GMT',
+        fecha_final: null,
+        meta_ventas: 1000,
+        productos_plan: 10,
+    }]
+
+    beforeEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    it('Prueba correcta de API listar planes de ventas', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }))
+
+        await microserviceSales.getSalesPlan()
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/vendedor/listar_planes'),
+            expect.objectContaining({
+                method: 'GET'
+            }),
+        )
+    })
+})

--- a/logistica-ccp/locales/en.json
+++ b/logistica-ccp/locales/en.json
@@ -122,10 +122,12 @@
         "table_col_4": "End Date",
         "table_col_5": "Goal",
         "table_col_6": "Products",
+        "table_col_7": "Close",
         "Report": "Report",
         "modal_title": "Sales Report",
         "modal_subtitle": "Sales report for the period: ",
         "modal_button_close": "CLOSE",
+        "close_plan": "Close",
 
         "route_modal_title": "Delivery Route",
         "route_modal_order": "Order: ",

--- a/logistica-ccp/locales/es.json
+++ b/logistica-ccp/locales/es.json
@@ -122,10 +122,12 @@
         "table_col_4": "Fecha Fin",
         "table_col_5": "Meta",
         "table_col_6": "Productos",
+        "table_col_7": "Cerrar",
         "Report": "Reporte",
         "modal_title": "Reporte Plan de Ventas",
         "modal_subtitle": "Reporte de Ventas para el periodo: ",
         "modal_button_close": "CERRAR",
+        "close_plan": "Cerrar",
 
         "route_modal_title": "Delivery Route",
         "route_modal_order": "Order: ",

--- a/logistica-ccp/src/app/[locale]/sales/adapters/microserviceSales.ts
+++ b/logistica-ccp/src/app/[locale]/sales/adapters/microserviceSales.ts
@@ -1,0 +1,23 @@
+const apiURI = "https://cr-bff-webapp-488938258128.us-central1.run.app"
+
+export const getSalesPlan = async (): Promise<any> => {
+    const url = apiURI + '/api/vendedor/listar_planes'
+    // const url = 'http://127.0.0.1:3005/listar_planes'
+    try {
+        const response = await fetch(url, {
+            method: 'GET',
+        });
+
+        if(!response.ok) {
+            const error_msg = await response.text()
+            throw new Error("No ha sido posible listar el plan de ventas: " + error_msg)
+        }
+        
+        const data = await response.json()
+        return data.body || [];
+    } 
+    catch (error) {
+        console.error("No ha sido posible listar el plan de ventas", error)
+        return []
+    }
+}

--- a/logistica-ccp/src/app/[locale]/sales/adapters/microserviceSales.ts
+++ b/logistica-ccp/src/app/[locale]/sales/adapters/microserviceSales.ts
@@ -21,3 +21,32 @@ export const getSalesPlan = async (): Promise<any> => {
         return []
     }
 }
+
+export const closePlan = async (closePlanData : {
+    id: string,
+}): Promise<any> => {
+    const url = apiURI + '/api/vendedor/finalizar_plan'
+    // const url = 'http://127.0.0.1:3005/finalizar_plan'
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(closePlanData),
+        });
+
+        if(!response.ok) {
+            const error_msg = await response.text()
+            throw new Error("No ha sido posible cerrar el plan de ventas: " + error_msg)
+        }
+        
+        const data = await response.json()
+        return data.body || [];
+    } 
+    catch (error) {
+        console.error("No ha sido posible cerrar el plan de ventas", error)
+        return []
+    }
+}

--- a/logistica-ccp/src/app/[locale]/sales/page.tsx
+++ b/logistica-ccp/src/app/[locale]/sales/page.tsx
@@ -9,7 +9,7 @@ import { GridColDef } from "@mui/x-data-grid";
 import AddIcon from '@mui/icons-material/Add';
 import { useTranslations } from "next-intl";
 import ModalReport from "./ModalReport";
-import { getSalesPlan } from "./adapters/microserviceSales";
+import { getSalesPlan, closePlan } from "./adapters/microserviceSales";
 
 declare module '@mui/material/Button' {
     interface ButtonPropsColorOverrides {
@@ -39,13 +39,41 @@ const formatDate = (dateString: string): string => {
 const Sales: React.FC = () => {
     const t = useTranslations('Sales')
 
+    const handleClosePlan = async (id: string) => {
+        console.log(`Cerrar registro ${id}`);
+        try {
+            const response = await closePlan({ id });
+            if (response) {
+                console.log("Plan cerrado exitosamente");
+            } else {
+                console.error("Error al cerrar el plan");
+            }
+        } catch (error) {
+            console.error("Error al cerrar el plan", error);
+        }
+    };
+
     const tableSchema: GridColDef[] = [
         {field: 'id', headerName: t('table_col_1'), flex: 1, headerClassName: styles.Header},
         {field: 'estado', headerName: t('table_col_2'), flex: 1, headerClassName: styles.Header},
         {field: 'fecha_inicio', headerName: t('table_col_3'), flex: 1, headerClassName: styles.Header},
         {field: 'fecha_final', headerName: t('table_col_4'), flex: 1, headerClassName: styles.Header},
         {field: 'meta_ventas', headerName: t('table_col_5'), flex: 1, headerClassName: styles.Header},
-        {field: 'productos_plan', headerName: t('table_col_6'), flex: 1, headerClassName: styles.Header}
+        {field: 'productos_plan', headerName: t('table_col_6'), flex: 1, headerClassName: styles.Header},
+        {field: 'acciones', headerName: t('table_col_7'), flex: 1, headerClassName: styles.Header,
+            renderCell: (params) => (
+                <Stack spacing={2} direction="row" justifyContent={'flex-end'}>
+                    <Button
+                        variant="contained"
+                        color="cpp"
+                        onClick={() => handleClosePlan(params.row.id)}
+                        disabled={params.row.estado == 'FINALIZADO'}
+                    >
+                        {t('close_plan')}
+                    </Button>
+                </Stack>
+            )
+        }
     ]
 
     const [isOpenReport, setIsOpenReport] = useState(false);

--- a/logistica-ccp/src/app/[locale]/sales/page.tsx
+++ b/logistica-ccp/src/app/[locale]/sales/page.tsx
@@ -9,6 +9,7 @@ import { GridColDef } from "@mui/x-data-grid";
 import AddIcon from '@mui/icons-material/Add';
 import { useTranslations } from "next-intl";
 import ModalReport from "./ModalReport";
+import { getSalesPlan } from "./adapters/microserviceSales";
 
 declare module '@mui/material/Button' {
     interface ButtonPropsColorOverrides {
@@ -21,27 +22,58 @@ interface Sales {
     id: string;
     estado: string;
     fecha_inicio: string;
-    fecha_fin: string;
+    fecha_final: string;
     meta_ventas: number;
-    productos: number;
+    productos_plan: number;
 }
 
+const formatDate = (dateString: string): string => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('es-ES', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+    });
+};
 
 const Sales: React.FC = () => {
     const t = useTranslations('Sales')
 
     const tableSchema: GridColDef[] = [
-        {field: 'ID Plan Ventas', headerName: t('table_col_1'), flex: 1, headerClassName: styles.Header},
-        {field: 'Estado', headerName: t('table_col_2'), flex: 1, headerClassName: styles.Header},
-        {field: 'Fecha Inicio', headerName: t('table_col_3'), flex: 1, headerClassName: styles.Header},
-        {field: 'Fecha Fin', headerName: t('table_col_4'), flex: 1, headerClassName: styles.Header},
-        {field: 'Meta Ventas', headerName: t('table_col_5'), flex: 1, headerClassName: styles.Header},
-        {field: 'Productos', headerName: t('table_col_6'), flex: 1, headerClassName: styles.Header}
+        {field: 'id', headerName: t('table_col_1'), flex: 1, headerClassName: styles.Header},
+        {field: 'estado', headerName: t('table_col_2'), flex: 1, headerClassName: styles.Header},
+        {field: 'fecha_inicio', headerName: t('table_col_3'), flex: 1, headerClassName: styles.Header},
+        {field: 'fecha_final', headerName: t('table_col_4'), flex: 1, headerClassName: styles.Header},
+        {field: 'meta_ventas', headerName: t('table_col_5'), flex: 1, headerClassName: styles.Header},
+        {field: 'productos_plan', headerName: t('table_col_6'), flex: 1, headerClassName: styles.Header}
     ]
 
     const [isOpenReport, setIsOpenReport] = useState(false);
     const [sales, setSales] = useState<Sales[]>([])
 
+    // const fetchSalesPlan = async () => {
+    //     const salesPlanList = await getSalesPlan();
+    //     setSales(salesPlanList);
+    // }
+
+    useEffect(() => {
+        const fetchSalesPlan = async () => {
+            const salesPlanList = await getSalesPlan();
+            setSales(salesPlanList);
+        };
+
+        const interval = setInterval(() => {
+            fetchSalesPlan();
+        }, 10000);
+        return () => clearInterval(interval);
+    }, []);
+
+    // Transform sales data to format dates before rendering
+    const formattedSales = sales.map((sale) => ({
+        ...sale,
+        fecha_inicio: formatDate(sale.fecha_inicio),
+        fecha_final: sale.fecha_final ? formatDate(sale.fecha_final) : "",
+    }));
 
     return (
         <Box>
@@ -65,7 +97,7 @@ const Sales: React.FC = () => {
                         </Grid>
                     </Grid>
                     <Grid size="grow" sx={{ margin: '1.25rem 6.25rem' }}>
-                        <DataTable columns={tableSchema} rows={sales} />
+                        <DataTable columns={tableSchema} rows={formattedSales} />
                     </Grid>
                 </Grid>
                 


### PR DESCRIPTION
This pull request introduces a new feature for interacting with the sales microservice, including fetching and closing sales plans. It also updates the user interface to reflect these changes, modifies localization files, and adds tests for the new functionality.

### Backend Integration with Sales Microservice:
* Added `getSalesPlan` and `closePlan` functions in `microserviceSales.ts` to fetch and close sales plans from the sales microservice. These functions handle API calls, error handling, and response parsing. ([logistica-ccp/src/app/[locale]/sales/adapters/microserviceSales.tsR1-R52](diffhunk://#diff-85cc92544a06590c27282286bc5c6f270ed8c6c496a21093d04f25d5645308f0R1-R52))

### Frontend Updates:
* Updated the `Sales` interface in `page.tsx` to match the API response structure (`fecha_final` and `productos_plan` fields). Added a `formatDate` utility function for date formatting. ([logistica-ccp/src/app/[locale]/sales/page.tsxL24-R104](diffhunk://#diff-ebfd5b14b2cc2626af7d6bc2a18ba0ce95d5b0c59f7200adb04a073e865420caL24-R104))
* Integrated the `getSalesPlan` function to periodically fetch sales plans and display them in the table. Added a "Close" button to each row, which uses the `closePlan` function to close a sales plan. ([logistica-ccp/src/app/[locale]/sales/page.tsxL24-R104](diffhunk://#diff-ebfd5b14b2cc2626af7d6bc2a18ba0ce95d5b0c59f7200adb04a073e865420caL24-R104), [logistica-ccp/src/app/[locale]/sales/page.tsxL68-R128](diffhunk://#diff-ebfd5b14b2cc2626af7d6bc2a18ba0ce95d5b0c59f7200adb04a073e865420caL68-R128))
* Updated the `DataTable` component to display formatted sales data. ([logistica-ccp/src/app/[locale]/sales/page.tsxL68-R128](diffhunk://#diff-ebfd5b14b2cc2626af7d6bc2a18ba0ce95d5b0c59f7200adb04a073e865420caL68-R128))

### Localization:
* Added new keys (`table_col_7` and `close_plan`) to English (`en.json`) and Spanish (`es.json`) localization files to support the "Close" button and column header. [[1]](diffhunk://#diff-9a3481bbf969ff5c6785846d434fa2de19748a762bf6ee87891b3c0435b70498R125-R130) [[2]](diffhunk://#diff-80b541fed4a58363736db050b26c8e5157818988552ea8ea08420f25000b19f0R125-R130)

### Testing:
* Added a test case in `salesMicroservice.test.tsx` to verify the correct interaction with the sales microservice API for fetching sales plans.